### PR TITLE
Added `Annotated` support.

### DIFF
--- a/taskiq_dependencies/graph.py
+++ b/taskiq_dependencies/graph.py
@@ -9,7 +9,7 @@ from taskiq_dependencies.dependency import Dependency
 try:
     from fastapi.params import Depends as FastapiDepends  # noqa: WPS433
 except ImportError:
-    FastapiDepends = None  # type: ignore
+    FastapiDepends = Dependency  # type: ignore
 
 
 class DependencyGraph:
@@ -136,9 +136,8 @@ class DependencyGraph:
                         + f"Please provide a type in param `{dep.parent.param_name}`"
                         + f" of `{dep.parent.dependency}`",
                     )
-                # We zip together names of parameters and the subsctituted values
-                # In parameters we would see TypeVars in args
-                # we would find actual classes.
+                # We zip together names of parameters and the substituted values
+                # for generics.
                 generics = zip(
                     parent_cls_origin.__parameters__,
                     parent_cls.__args__,  # type: ignore
@@ -172,13 +171,14 @@ class DependencyGraph:
             # default vaule.
             for param_name, param in sign.parameters.items():
                 default_value = param.default
+                if hasattr(param.annotation, "__metadata__"):  # noqa: WPS421
+                    for meta in param.annotation.__metadata__:
+                        if isinstance(meta, (Dependency, FastapiDepends)):
+                            default_value = meta
 
                 # This is for FastAPI integration. So you can
                 # use Depends from taskiq mixed with fastapi's dependencies.
-                if FastapiDepends is not None and isinstance(  # noqa: WPS337
-                    default_value,
-                    FastapiDepends,
-                ):
+                if isinstance(default_value, FastapiDepends):
                     default_value = Dependency(
                         dependency=default_value.dependency,
                         use_cache=default_value.use_cache,

--- a/tests/test_annotated.py
+++ b/tests/test_annotated.py
@@ -1,0 +1,76 @@
+import sys
+
+import pytest
+
+if sys.version_info < (3, 10):
+    pytest.skip("Annotated is available only for python 3.10+", allow_module_level=True)
+
+from typing import Annotated, AsyncGenerator, Generic, TypeVar
+
+from taskiq_dependencies import DependencyGraph, Depends
+
+
+def test_annotated_func() -> None:
+    def get_int() -> int:
+        return 1
+
+    def target_func(dep: Annotated[int, Depends(get_int)]) -> int:
+        return dep
+
+    with DependencyGraph(target_func).sync_ctx() as ctx:
+        res = target_func(**ctx.resolve_kwargs())
+    assert res == 1
+
+
+def test_annotated_class() -> None:
+    class TestClass:
+        pass
+
+    def target_func(dep: Annotated[TestClass, Depends()]) -> TestClass:
+        return dep
+
+    with DependencyGraph(target_func).sync_ctx() as ctx:
+        res = target_func(**ctx.resolve_kwargs())
+    assert isinstance(res, TestClass)
+
+
+def test_annotated_generic() -> None:
+    _T = TypeVar("_T")
+
+    class MyClass:
+        pass
+
+    class MainClass(Generic[_T]):
+        def __init__(self, val: _T = Depends()) -> None:
+            self.val = val
+
+    def test_func(a: Annotated[MainClass[MyClass], Depends()]) -> MyClass:
+        return a.val
+
+    with DependencyGraph(target=test_func).sync_ctx(exception_propagation=False) as g:
+        value = test_func(**(g.resolve_kwargs()))
+
+    assert isinstance(value, MyClass)
+
+
+@pytest.mark.anyio
+async def test_annotated_asyncgen() -> None:
+    opened = False
+    closed = False
+
+    async def my_gen() -> AsyncGenerator[int, None]:
+        nonlocal opened, closed
+        opened = True
+
+        yield 1
+
+        closed = True
+
+    def test_func(dep: Annotated[int, Depends(my_gen)]) -> int:
+        return dep
+
+    async with DependencyGraph(target=test_func).async_ctx() as g:
+        value = test_func(**(await g.resolve_kwargs()))
+        assert value == 1
+
+    assert opened and closed

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -1,5 +1,8 @@
+import sys
 from typing import Any
 from unittest.mock import patch
+
+import pytest
 
 from taskiq_dependencies import DependencyGraph
 
@@ -23,6 +26,30 @@ def test_dependency_swap() -> None:
             return 1
 
         def func_b(dep_a: int = MyFastapiDepends(func_a)) -> int:  # type: ignore
+            return dep_a
+
+        with DependencyGraph(func_b).sync_ctx() as ctx:
+            kwargs = ctx.resolve_kwargs()
+
+        assert kwargs == {"dep_a": 1}
+
+
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="Only for python 3.10+")
+def test_dependency_swap_annotated() -> None:
+    """
+    Test that dependency classes are swapped.
+
+    This test checks that if function depends on FastAPI depends, it will
+    be swapped and resolved.
+    """
+    from typing import Annotated
+
+    with patch("taskiq_dependencies.graph.FastapiDepends", MyFastapiDepends):
+
+        def func_a() -> int:
+            return 1
+
+        def func_b(dep_a: Annotated[int, MyFastapiDepends(func_a)]) -> int:  # type: ignore
             return dep_a
 
         with DependencyGraph(func_b).sync_ctx() as ctx:


### PR DESCRIPTION
Now users can use `Annotated` for specifying dependencies.