### PR TITLE
Skip functions with undefined types.

### DIFF
--- a/taskiq_dependencies/dependency.py
+++ b/taskiq_dependencies/dependency.py
@@ -156,3 +156,15 @@ class Dependency:
         if not isinstance(rhs, Dependency):
             return False
         return self._id == rhs._id
+
+    def __repr__(self) -> str:
+        func_name = str(self.dependency)
+        if self.dependency is not None and hasattr(self.dependency, "__name__"):
+            func_name = self.dependency.__name__
+        return (
+            f"Dependency({func_name}, "
+            f"use_cache={self.use_cache}, "
+            f"kwargs={self.kwargs}, "
+            f"parent={self.parent}"
+            ")"
+        )

--- a/taskiq_dependencies/graph.py
+++ b/taskiq_dependencies/graph.py
@@ -1,5 +1,4 @@
 import inspect
-import os
 import sys
 import warnings
 from collections import defaultdict, deque
@@ -177,13 +176,13 @@ class DependencyGraph:
                 try:
                     hints = get_type_hints(origin.__init__)
                 except NameError:
-                    _, src_lineno = inspect.getsourcelines(dep.dependency)
-                    src_file = Path(inspect.getfile(dep.dependency)).relative_to(
+                    _, src_lineno = inspect.getsourcelines(origin)
+                    src_file = Path(inspect.getfile(origin)).relative_to(
                         Path.cwd(),
                     )
                     warnings.warn(
                         "Cannot resolve type hints for "
-                        f"a class {dep.dependency.__name__} defined "
+                        f"a class {origin.__name__} defined "
                         f"at {src_file}:{src_lineno}.",
                         RuntimeWarning,
                         stacklevel=2,
@@ -198,7 +197,7 @@ class DependencyGraph:
                 try:
                     hints = get_type_hints(dep.dependency)
                 except NameError:
-                    _, src_lineno = inspect.getsourcelines(dep.dependency)
+                    _, src_lineno = inspect.getsourcelines(dep.dependency)  # type: ignore
                     src_file = Path(inspect.getfile(dep.dependency)).relative_to(
                         Path.cwd(),
                     )

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,4 +1,3 @@
-from collections import UserString
 import re
 import uuid
 from contextlib import asynccontextmanager, contextmanager

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,7 +1,16 @@
+from collections import UserString
 import re
 import uuid
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, AsyncGenerator, Generator, Generic, Tuple, TypeVar
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    AsyncGenerator,
+    Generator,
+    Generic,
+    Tuple,
+    TypeVar,
+)
 
 import pytest
 
@@ -891,3 +900,56 @@ def test_param_info_subgraph() -> None:
     assert info.name == ""
     assert info.definition is None
     assert info.graph == graph
+
+
+def test_skip_type_checking_function() -> None:
+    """Test if we can skip type only for type checking for the function."""
+    if TYPE_CHECKING:
+
+        class A:
+            pass
+
+    def target(unknown: "A") -> None:
+        pass
+
+    with pytest.warns(RuntimeWarning, match=r"Cannot resolve.*function target.*"):
+        graph = DependencyGraph(target=target)
+    with graph.sync_ctx() as ctx:
+        assert "unknown" not in ctx.resolve_kwargs()
+
+
+def test_skip_type_checking_class() -> None:
+    """Test if we can skip type only for type checking for the function."""
+    if TYPE_CHECKING:
+
+        class A:
+            pass
+
+    class Target:
+        def __init__(self, unknown: "A") -> None:
+            pass
+
+    with pytest.warns(RuntimeWarning, match=r"Cannot resolve.*class Target.*"):
+        graph = DependencyGraph(target=Target)
+    with graph.sync_ctx() as ctx:
+        assert "unknown" not in ctx.resolve_kwargs()
+
+
+def test_skip_type_checking_object() -> None:
+    """Test if we can skip type only for type checking for the function."""
+    if TYPE_CHECKING:
+
+        class A:
+            pass
+
+    class Target:
+        def __call__(self, unknown: "A") -> None:
+            pass
+
+    with pytest.warns(
+        RuntimeWarning,
+        match=r"Cannot resolve.*object of class Target.*",
+    ):
+        graph = DependencyGraph(target=Target())
+    with graph.sync_ctx() as ctx:
+        assert "unknown" not in ctx.resolve_kwargs()


### PR DESCRIPTION
Sometimes in some libraries we have types defined only for `TYPE_CHECKING`. This PR relaxes dependency resolutions for such cases.